### PR TITLE
PHPDoc compliance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,122 @@
+name: Moodle Plugin CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: 'postgres'
+          POSTGRES_HOST_AUTH_METHOD: 'trust'
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
+
+      mariadb:
+        image: mariadb:10
+        env:
+          MYSQL_USER: 'root'
+          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+          MYSQL_CHARACTER_SET_SERVER: "utf8mb4"
+          MYSQL_COLLATION_SERVER: "utf8mb4_unicode_ci"
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 3
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['7.4', '8.0', '8.1']
+        moodle-branch: ['MOODLE_401_STABLE']
+        database: [pgsql, mariadb]
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+        with:
+          path: plugin
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: ${{ matrix.extensions }}
+          ini-values: max_input_vars=5000
+          # If you are not using code coverage, keep "none". Otherwise, use "pcov" (Moodle 3.10 and up) or "xdebug".
+          # If you try to use code coverage with "none", it will fallback to phpdbg (which has known problems).
+          coverage: none
+
+      - name: Initialise moodle-plugin-ci
+        run: |
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^4
+          echo $(cd ci/bin; pwd) >> $GITHUB_PATH
+          echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
+          sudo locale-gen en_AU.UTF-8
+          echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
+
+      - name: Install moodle-plugin-ci
+        run: moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
+        env:
+          DB: ${{ matrix.database }}
+          MOODLE_BRANCH: ${{ matrix.moodle-branch }}
+          # Uncomment this to run Behat tests using the Moodle App.
+          # MOODLE_APP: 'true'
+
+      - name: PHP Lint
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phplint
+
+      - name: PHP Mess Detector
+        continue-on-error: true # This step will show errors but will not fail
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpmd
+
+      - name: Moodle Code Checker
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpcs --max-warnings 0
+
+      - name: Moodle PHPDoc Checker
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpdoc --max-warnings 0
+
+      - name: Validating
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci validate
+
+      - name: Check upgrade savepoints
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci savepoints
+
+      - name: Mustache Lint
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci mustache
+
+      - name: Grunt
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci grunt --max-lint-warnings 0
+
+      - name: PHPUnit tests
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpunit --fail-on-warning
+
+      - name: Behat features
+        id: behat
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci behat --profile chrome --scss-deprecations
+
+      - name: Upload Behat Faildump
+        if: ${{ failure() && steps.behat.outcome == 'failure' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: Behat Faildump (${{ join(matrix.*, ', ') }})
+          path: ${{ github.workspace }}/moodledata/behat_dump
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Mark cancelled jobs as failed.
+        if: ${{ cancelled() }}
+        run: exit 1

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -1,0 +1,23 @@
+<?php
+namespace local_yeswecanquiz\privacy;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Privacy "null" provider for local_yeswecanquiz.
+ *
+ * This plugin does not store any personal user data.
+ */
+class provider implements
+    \core_privacy\local\metadata\null_provider {
+
+    /**
+     * Returns the language string identifier that explains
+     * why this plugin stores no data.
+     *
+     * @return  string
+     */
+    public static function get_reason(): string {
+        return 'privacy:metadata';
+    }
+}

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -1,13 +1,31 @@
 <?php
 namespace local_yeswecanquiz\privacy;
 
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 defined('MOODLE_INTERNAL') || die();
 
 /**
- * Privacy "null" provider for local_yeswecanquiz.
+ * Plugin settings definition for YesWeCanQuiz.
  *
- * This plugin does not store any personal user data.
+ * @package    local_yeswecanquiz
+ * @copyright  2025 Ikrame Saadi (@ikramagix) <hello@yeswecanquiz.eu>
+ * @license    https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
  */
+
 class provider implements
     \core_privacy\local\metadata\null_provider {
 

--- a/lang/en/local_yeswecanquiz.php
+++ b/lang/en/local_yeswecanquiz.php
@@ -14,18 +14,16 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+defined('MOODLE_INTERNAL') || die();
+
 /**
  * English language file for YesWeCanQuiz plugin.
  *
- * @package   yeswecanquiz
- * @author    Ikrame Saadi (@ikramagix)
- * @copyright 2025 Ikrame Saadi (@ikramagix) {@link https://yeswecanquiz.eu}
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
- * @contact   hello@yeswecanquiz.eu
+ * @package    local_yeswecanquiz
+ * @copyright  2025 Ikrame Saadi (@ikramagix) <hello@yeswecanquiz.eu>
+ * @license    https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
  */
 
-
-defined('MOODLE_INTERNAL') || die();
 
 $string['pluginname']         = 'YesWeCanQuiz';
 $string['publicuserid']       = 'Public User ID';

--- a/lang/en/local_yeswecanquiz.php
+++ b/lang/en/local_yeswecanquiz.php
@@ -31,3 +31,4 @@ $string['pluginname']         = 'YesWeCanQuiz';
 $string['publicuserid']       = 'Public User ID';
 $string['publicuserid_desc']  = 'Select the user account that will be used for guest quiz attempts.';
 $string['settings']           = 'YesWeCanQuiz Settings';
+$string['privacy:metadata'] = 'The YesWeCanQuiz plugin does not store any personal user data.';

--- a/lib.php
+++ b/lib.php
@@ -34,7 +34,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-function yeswecanquiz_session_control() {
+function local_yeswecanquiz_session_control() {
     global $USER, $DB, $SCRIPT;
 
     // Get the public user ID from plugin settings.
@@ -44,8 +44,8 @@ function yeswecanquiz_session_control() {
     }
 
     // Avoid loops by using a session flag array.
-    if (!isset($_SESSION['yeswecanquiz_newattempt'])) {
-        $_SESSION['yeswecanquiz_newattempt'] = array();
+    if (!isset($_SESSION['local_yeswecanquiz_newattempt'])) {
+        $_SESSION['local_yeswecanquiz_newattempt'] = array();
     }
 
     // CASE 1: On quiz view page.
@@ -65,7 +65,7 @@ function yeswecanquiz_session_control() {
             if (isset($_GET['id'])) {
                 $cmid = required_param('id', PARAM_INT);
                 // Only process once per quiz view to avoid looping.
-                if (empty($_SESSION['yeswecanquiz_newattempt'][$cmid])) {
+                if (empty($_SESSION['local_yeswecanquiz_newattempt'][$cmid])) {
                     // Get course module and quiz records.
                     $cm = get_coursemodule_from_id('quiz', $cmid, 0, false, MUST_EXIST);
                     $quiz = $DB->get_record('quiz', array('id' => $cm->instance), '*', MUST_EXIST);
@@ -78,7 +78,7 @@ function yeswecanquiz_session_control() {
                         }
                     }
                     // Mark that we have processed this quiz.
-                    $_SESSION['yeswecanquiz_newattempt'][$cmid] = true;
+                    $_SESSION['local_yeswecanquiz_newattempt'][$cmid] = true;
                     // Redirect to the attempt page so Moodle creates a new attempt.
                     $attempturl = new moodle_url('/mod/quiz/attempt.php', array('attempt' => 0, 'id' => $cmid));
                     redirect($attempturl);
@@ -110,12 +110,12 @@ function yeswecanquiz_session_control() {
  * Hook callback: triggers session control early.
  */
 function local_yeswecanquiz_before_http_headers() {
-    yeswecanquiz_session_control();
+    local_yeswecanquiz_session_control();
 }
 
 /**
  * Fallback hook – triggered when Moodle builds the navigation.
  */
-function yeswecanquiz_extend_navigation(global_navigation $navigation) {
-    yeswecanquiz_session_control();
+function local_yeswecanquiz_extend_navigation(global_navigation $navigation) {
+    local_yeswecanquiz_session_control();
 }

--- a/lib.php
+++ b/lib.php
@@ -1,5 +1,5 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -14,25 +14,29 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
- /**
-  * Core logic for the YesWeCanQuiz plugin.
-  * 
-  * @package   yeswecanquiz
-  * @author    Ikrame Saadi (@ikramagix)
-  * @copyright 2025 Ikrame Saadi (@ikramagix) {@link https://yeswecanquiz.eu}
-  * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
-  * @contact   hello@yeswecanquiz.eu
-  *
-  * The following logic is used to control the session and force new quiz attempts for the public user:
-  * - On any /mod/quiz/ page, if the user is not logged in (or is a guest), log them in as the public user.
-  * - On the quiz view page (view.php), if the user is the public user,
-  *   update any unfinished attempt for that quiz to state "finished"
-  *   (thus disabling the option to resume) and then redirect to the attempt page.
-  * - Outside /mod/quiz/ pages, if the public user is logged in, log them out.
-  */
-
-
 defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Core library for the YesWeCanQuiz plugin.
+ *
+ * Controls session behaviour and navigation alterations for the public user.
+ *
+ * @package    local_yeswecanquiz
+ * @copyright  2025 Ikrame Saadi (@ikramagix) <hello@yeswecanquiz.eu>
+ * @license    https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ */
+
+ /**
+ * Enforce quiz session rules for the public user.
+ *
+ * - On /mod/quiz/view.php, mark any unfinished attempt as finished and redirect.
+ * - Outside quiz pages, log out the public user.
+ *
+ * @global \stdClass         $USER   Current user object.
+ * @global \moodle_database  $DB     Moodle database API.
+ * @global string            $SCRIPT The current script path.
+ * @return void
+ */
 
 function local_yeswecanquiz_session_control() {
     global $USER, $DB, $SCRIPT;
@@ -107,15 +111,26 @@ function local_yeswecanquiz_session_control() {
 }
 
 /**
- * Hook callback: triggers session control early.
+ * Hook to run before HTTP headers are sent.
+ *
+ * Calls session control logic for public-user enforcement.
+ *
+ * @return void
  */
+
 function local_yeswecanquiz_before_http_headers() {
     local_yeswecanquiz_session_control();
 }
 
 /**
- * Fallback hook – triggered when Moodle builds the navigation.
+ * Extend the course navigation for the public user.
+ *
+ * Adjusts or hides navigation nodes to enforce the new-attempt policy.
+ *
+ * @param  \global_navigation  $navigation The navigation tree.
+ * @return void
  */
+
 function local_yeswecanquiz_extend_navigation(global_navigation $navigation) {
     local_yeswecanquiz_session_control();
 }

--- a/settings.php
+++ b/settings.php
@@ -14,20 +14,31 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Admin settings file.
- *
- * @package   yeswecanquiz
- * @author    Ikrame Saadi (@ikramagix)
- * @copyright 2025 Ikrame Saadi (@ikramagix) {@link https://yeswecanquiz.eu}
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
- * @contact   hello@yeswecanquiz.eu
- */
-
-
 defined('MOODLE_INTERNAL') || die();
 
-if ($hassiteconfig) {
+/**
+ * Plugin settings definition for the YesWeCanQuiz plugin.
+ *
+ * Adds a page under “Local plugins” where the admin selects
+ * the public user account for quiz attempts.
+ *
+ * @package    local_yeswecanquiz
+ * @copyright  2025 Ikrame Saadi
+ * @license    https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ */
+
+/**
+ * Define the YesWeCanQuiz admin settings page.
+ *
+ * - Creates an admin_settingpage under “Local plugins”
+ * - Adds a dropdown of all manual-account users for public‐quiz usage
+ *
+ * @global \moodle_database $DB    Moodle DB API.
+ * @global \admin_root      $ADMIN Admin settings tree.
+ * @return void
+ */
+
+if ($hassiteconfig)  {
     $settings = new admin_settingpage('local_yeswecanquiz', get_string('pluginname', 'local_yeswecanquiz'));
 
     // Build user selection dropdown for Public User (only manual accounts).

--- a/version.php
+++ b/version.php
@@ -14,17 +14,16 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+defined('MOODLE_INTERNAL') || die();
+
 /**
  * Version file for YesWeCanQuiz plugin.
  * 
- * @package   yeswecanquiz
- * @author    Ikrame Saadi (@ikramagix)
- * @copyright 2025 Ikrame Saadi (@ikramagix) {@link https://yeswecanquiz.eu}
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
- * @contact   hello@yeswecanquiz.eu
+ * @package    local_yeswecanquiz
+ * @copyright  2025 Ikrame Saadi (@ikramagix) <hello@yeswecanquiz.eu>
+ * @license    https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_yeswecanquiz'; // MUST start with 'local_' for Moodle to detect it
 $plugin->type = 'local'; // Explicitly define as a local plugin


### PR DESCRIPTION
### PHPDoc compliance for Moodle’s PHPDoc standards

- Added file-level docblock with @package, @copyright and @license  
- Added settings-page docblock describing its purpose, globals ($DB, $ADMIN) and return type  

This completes issue #5. 